### PR TITLE
Fix multi-line spinner messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "cli-table": "^0.3.1",
+    "strip-ansi": "^5.0.0",
     "wrap-ansi": "^2.0.0"
   }
 }

--- a/primitives.js
+++ b/primitives.js
@@ -45,6 +45,14 @@ function formatString(string, formatting) {
 	return formatting.reduce((c, formattingOption) => c[formattingOption], chalk)(string);
 }
 
+function getLeftIndentationString (indentation, indentationLevel) {
+	let str = '';
+	for(let i = 0; i < indentationLevel; ++i) {
+		str += indentation;
+	}
+	return str;
+}
+
 function getTerminalWidth () {
 	return process.stdout.columns;
 }
@@ -55,5 +63,6 @@ module.exports = {
 	indentString: indentString,
 	padString: padString,
 	fillString: fillString,
+	getLeftIndentationString: getLeftIndentationString,
 	getTerminalWidth: getTerminalWidth
 };

--- a/test.js
+++ b/test.js
@@ -68,8 +68,15 @@ softSpoken.outdent();
 softSpoken.log('Outdent');
 softSpoken.definition('nerf', 'A word also commonly said by wvbe');
 
+const destroySpinner = softSpoken.spinner('Spinnermesome');
 return new Promise(res => setTimeout(res, 1000))
-	.then(softSpoken.spinner('Spinnermesome'))
+	.then(() => {
+		softSpoken.notice('Interrupted spinner with a message');
+		return new Promise(res => setTimeout(res, 1000));
+	})
+	.then(() => {
+		destroySpinner();
+	})
 	.then(() => {
 		softSpoken.list([
 			'One',


### PR DESCRIPTION
When a spinner message spans multiple lines, either due to a long message or a small console, only one line is cleared after which the complete multi line spinner message is outputted again causing the console to output to be spammed with the message.

This fix correctly handles multi line console output and clears the last line correctly. It also checks if the spinner animation and done message (xxx ms) is placed on a new line when it does not fit on the last line. When some other log message is outputted while the spinner is active, the whole spinner message is outputted again.

Known issues:
* When the console width changes while the spinner is active, the output is not optimal.